### PR TITLE
Update README.md for error after install eslint

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Finally, we update `package.json` with related format scripts.
 We want to have consistency in our codebase and also want to catch mistakes. So, we need to install ESLint.
 
 ```sh
-yarn add eslint @atolye15/eslint-config --dev
+yarn add @atolye15/eslint-config --dev
 ```
 `.eslintrc`
 


### PR DESCRIPTION
When the command `yarn add eslint @atolye15/eslint-config --dev` is run in the Install Eslint step, the project cannot be run, an error occurs.

The error occurs because we add eslint to dependencies. Create-react-app (react-scripts) already comes with eslint. (unfortunately its using an older version of eslint now). This error is happening now. Maybe it might disappear if React-scripts is updated. But in the future, errors may occur again. As long as the create-react-app comes with eslint, lets not install eslint.

Installing eslint seems like the right approach since we are configuring Eslint. However i think not installing eslint seems to be the best solution for now because of the error. 

The error is as follows:

```
yarn run v1.22.5
$ react-scripts start

There might be a problem with the project dependency tree.
It is likely not a bug in Create React App, but something you need to fix locally.

The react-scripts package provided by Create React App requires a dependency:

  "eslint": "^6.6.0"

Don't try to install it manually: your package manager does it automatically.
However, a different version of eslint was detected higher up in the tree:

  /Users/tonguc/Projects/catalogueasy/deneme/node_modules/eslint (version: 7.10.0)

Manually installing incompatible versions is known to cause hard-to-debug issues.

If you would prefer to ignore this check, add SKIP_PREFLIGHT_CHECK=true to an .env file in your project.
That will permanently disable this message but you might encounter other issues.

To fix the dependency tree, try following the steps below in the exact order:

  1. Delete package-lock.json (not package.json!) and/or yarn.lock in your project folder.
  2. Delete node_modules in your project folder.
  3. Remove "eslint" from dependencies and/or devDependencies in the package.json file in your project folder.
  4. Run npm install or yarn, depending on the package manager you use.

In most cases, this should be enough to fix the problem.
If this has not helped, there are a few other things you can try:

  5. If you used npm, install yarn (http://yarnpkg.com/) and repeat the above steps with it instead.
     This may help because npm has known issues with package hoisting which may get resolved in future versions.

  6. Check if /Users/tonguc/Projects/catalogueasy/deneme/node_modules/eslint is outside your project directory.
     For example, you might have accidentally installed something in your home folder.

  7. Try running npm ls eslint in your project folder.
     This will tell you which other package (apart from the expected react-scripts) installed eslint.

If nothing else helps, add SKIP_PREFLIGHT_CHECK=true to an .env file in your project.
That would permanently disable this preflight check in case you want to proceed anyway.

P.S. We know this message is long but please read the steps above :-) We hope you find them helpful!

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```